### PR TITLE
Fix calls using old function signatures

### DIFF
--- a/src/main/clojure/clojure/tools/nrepl/cmdline.clj
+++ b/src/main/clojure/clojure/tools/nrepl/cmdline.clj
@@ -39,7 +39,7 @@
                err print
                out print
                value print}}]
-    (let [connection (repl/connect "localhost" port)
+    (let [connection (repl/connect :host "localhost" :port port)
           {:keys [major minor incremental qualifier]} *clojure-version*]
       (println "network-repl")
       (println (str "Clojure " (clojure-version)))
@@ -71,7 +71,8 @@
 (defn -main
   [& args]
   (let [[options args] (split-args args)
-        [ssocket _] (start-server (Integer/parseInt (or (options "--port") "0")))]
+        server (start-server :port (Integer/parseInt (or (options "--port") "0")))
+        ssocket (:ss @server)]
     (when-let [ack-port (options "--ack")]
       (binding [*out* *err*]
         (println (format "ack'ing my port %d to other server running on port %s"


### PR DESCRIPTION
It looks like these were never updated when the API was changed.

Thanks for nREPL!
