### PR TITLE
Bind server to "::" instead of "localhost"

### DIFF
--- a/src/main/clojure/clojure/tools/nrepl/server.clj
+++ b/src/main/clojure/clojure/tools/nrepl/server.clj
@@ -139,7 +139,7 @@
   [& {:keys [port bind transport-fn handler ack-port greeting-fn] :or {port 0}}]
   (let [bind-addr (if bind
                     (InetSocketAddress. ^String bind ^Integer port)
-                    (InetSocketAddress. "localhost" port))
+                    (InetSocketAddress. "::" port))
         ss (doto (ServerSocket.)
              (.setReuseAddress true)
              (.bind bind-addr))


### PR DESCRIPTION
This change causes the nrepl server to listen on both ipv4 and ipv6
localhost.  This helps on systems where localhost is defined as name
for both ::1 and 127.0.0.1.

https://docs.oracle.com/javase/8/docs/technotes/guides/net/ipv6_guide/